### PR TITLE
Fixed Bug with Absolute Coor Mode

### DIFF
--- a/MouseDisplayOff/MouseDisplayOff.ahk
+++ b/MouseDisplayOff/MouseDisplayOff.ahk
@@ -3,17 +3,22 @@
 #SingleInstance
 SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
 SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
-
-;SysGet, MCount, MonitorPrimary
-
-SysGet, Msize, Monitor
+CoordMode, Mouse, Screen; Sets the Mouse value to absolute coor on screen
 On := 1
 ; PREVX := -1
 ; PREVY := -1
-MAXX := MsizeRight-5
-MAXY := MsizeBottom-5
+
 loop{
+	
+	SysGet, MCount, MonitorPrimary
+	SysGet, Msize, Monitor
+	MAXX := MsizeRight-5
+	MAXY := MsizeBottom-5
+		
 	MouseGetPos, x, y
+
+	;MsgBox, %x%, %y% Purely for debugging purpose
+
 	if(On>0) ; Display is On 
 	{
 		; MsgBox, %x%, " ", %y%


### PR DESCRIPTION
Mouse Coordinate Mode was previously set to relative to window  size. Fixed by making coordinate mode absolute to size of monitor